### PR TITLE
in README.md: fix param name in #add_attribute

### DIFF
--- a/encoders/ruby/README.md
+++ b/encoders/ruby/README.md
@@ -31,7 +31,7 @@ keys if required by your application:
 
 ```ruby
 @pack_set.add_attribute(
-  name: :bucket,
+  attr_name: :bucket,
   possibilities: @project.buckets.map(&:downcase),
   max_choices: 1
 )
@@ -41,7 +41,7 @@ keys if required by your application:
 
 ```ruby
 @pack_set.add_buffered_attribute(
-  name: 'name'
+  attr_name: 'name'
 )
 ```
 


### PR DESCRIPTION
# add_attribute and #add_buffered_attribute seem to require the use of :attr_name (as oppposed to :name)
